### PR TITLE
Upgrade to `Snipcart v3.0.21` plus fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-You are free to:
-Share — copy and redistribute the material in any medium or format
-Adapt — remix, transform, and build upon the material
-for any purpose, even commercially.
- This license is acceptable for Free Cultural Works.
-The licensor cannot revoke these freedoms as long as you follow the license terms.
-Under the following terms:
-Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+MIT License
 
-No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
-Notices:
-You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
-No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+Copyright (c) 2020 Themefisher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,13 @@
-MIT License
+You are free to:
+Share — copy and redistribute the material in any medium or format
+Adapt — remix, transform, and build upon the material
+for any purpose, even commercially.
+ This license is acceptable for Free Cultural Works.
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+Under the following terms:
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
 
-Copyright (c) 2020 Themefisher
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+Notices:
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,25 +28,25 @@ disqusShortname = ""
   [[params.plugins.js]]
   link = "plugins/google-map/gmap.js"
 
-  
+
 ############################## navigation ###############################
 [menu]
-    
+
   [[menu.main]]
   name = "Products"
   URL = "products"
   weight = 1
-  
+
   [[menu.main]]
   name = "Blog"
   URL = "blog"
   weight = 2
-  
+
   [[menu.main]]
   name = "FAQ"
   URL = "faq"
   weight = 3
-  
+
   [[menu.main]]
   name = "Contact"
   URL = "contact"
@@ -57,22 +57,22 @@ disqusShortname = ""
   name = "Products"
   URL = "products"
   weight = 1
-  
+
   [[menu.footer]]
   name = "Blog"
   URL = "blog"
   weight = 2
-  
+
   [[menu.footer]]
   name = "FAQ"
   URL = "faq"
   weight = 3
-  
+
   [[menu.footer]]
   name = "Terms & Conditions"
   URL = "terms-conditions"
   weight = 4
-  
+
   [[menu.footer]]
   name = "Contact"
   URL = "contact"
@@ -99,6 +99,8 @@ email = "demo@email.com"
 location = "Dhaka, Bangladedsh"
 # copyright
 copyright = "| Copyright &copy; 2019 [Gethugothemes](https://gethugothemes.com) All Rights Reserved |"
+# Snipcart Credentials
+snipcartApiKey = "M2E5YjA3NjMtYzRiYS00YzVjLWEyYWYtNDY5ZDI0OWZhYjg5"
 
   # Preloader
   [params.preloader]
@@ -116,19 +118,19 @@ copyright = "| Copyright &copy; 2019 [Gethugothemes](https://gethugothemes.com) 
   [[params.social]]
   icon = "ti-facebook"
   link = "#"
-  
+
   [[params.social]]
   icon = "ti-twitter-alt"
   link = "#"
-  
+
   [[params.social]]
   icon = "ti-youtube"
   link = "#"
-  
+
   [[params.social]]
   icon = "ti-instagram"
   link = "#"
-  
+
   [[params.social]]
   icon = "ti-pinterest"
   link = "#"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -178,12 +178,12 @@
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
             <p>{{ .Params.Description }}</p>
             <div class="mb-4">
-              <span class="lead text-primary">{{ .Params.Price }}</span>
-              <s>{{ .Params.PriceBefore }}</s>
+              <span class="lead text-primary">${{ .Params.Price }}</span>
+              <s>${{ .Params.PriceBefore }}</s>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
               data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
-              {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}">
+              {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
               Add to cart
             </button>
           </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -57,13 +57,15 @@
 {{ end }}
 
 <!-- snipcart -->
-<script type="text/javascript" id="snipcart" src="https://cdn.snipcart.com/scripts/2.0/snipcart.js"
-  data-api-key="M2E5YjA3NjMtYzRiYS00YzVjLWEyYWYtNDY5ZDI0OWZhYjg5"></script>
+{{ with site.Params.snipcartApiKey }}
+<script type="text/javascript" id="snipcart" src="https://cdn.snipcart.com/themes/v3.0.21/default/snipcart.js"
+  data-api-key="{{ site.Params.snipcartApiKey }}"></script>
 <script>
   Snipcart.execute('registerLocale', 'en', {
-    powered_by: "Themefisher"
+    powered_by: "Enlazaa"
   });
 </script>
+{{ end }}
 
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,10 @@
   {{ range site.Params.plugins.css }}
   <link rel="stylesheet" href="{{ .link | absURL }}">
   {{ end }}
-  <link id="snipcart-theme" type="text/css" href="https://cdn.snipcart.com/themes/2.0/base/snipcart.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://app.snipcart.com">
+  <link rel="preconnect" href="https://cdn.snipcart.com">
+  <link id="snipcart-theme" type="text/css" href="https://cdn.snipcart.com/themes/v3.0.21/default/snipcart.css" rel="stylesheet">
+  <script async src="https://cdn.snipcart.com/themes/v3.0.21/default/snipcart.js"></script>
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify }}

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -17,12 +17,12 @@
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
             <p>{{ .Params.Description }}</p>
             <div class="mb-4">
-              <span class="lead text-primary">{{ .Params.Price }}</span>
-              <s>{{ .Params.PriceBefore }}</s>
+              <span class="lead text-primary">${{ .Params.Price }}</span>
+              <s>${{ .Params.PriceBefore }}</s>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
               data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
-              {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}">
+              {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
               Add to cart
             </button>
           </div>

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -22,14 +22,14 @@
         <div class="rw-ui-container"></div>
         {{ end }}
         <div class="my-4">
-          <span class="lead text-primary font-weight-medium">{{ .Params.Price }}</span>
-          <s>{{ .Params.PriceBefore }}</s>
+          <span class="lead text-primary font-weight-medium">${{ .Params.Price }}</span>
+          <s>${{ .Params.PriceBefore }}</s>
         </div>
         <h5>Short Description</h5>
         <p>{{ .Params.ShortDescription | markdownify }}</p>
         <button class="snipcart-add-item btn btn-primary" data-item-id="{{ .Params.ProductID }}"
           data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
-          {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}">
+          {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
           Add to cart
         </button>
       </div>


### PR DESCRIPTION
Hello @mehedi-sharif,

This theme is **FANTASTIC** and I wanted help out. I installed this theme and I noticed the base branch is using `snipcart` **v2.0** while a newer version exists.

I have spent time upgrading the theme to use new `snipcart` **v3.0** code along with a few fixes. The details are in the commits; in addition, I have tested my site with the latest v3.0 and the theme works. :)

May you please take a look and merge if acceptable? If not, let me know how I can help.

Thank you and looking forward!