### PR TITLE
Fix strikethrough price displayed for products without discounted price

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -178,8 +178,10 @@
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
             <p>{{ .Params.Description }}</p>
             <div class="mb-4">
-              <span class="lead text-primary">{{ .Params.Price }} {{ site.Params.currencySymbol }}</span>
-              <s>{{ .Params.PriceBefore }} {{ site.Params.currencySymbol }}</s>
+              {{ if .Params.PriceBefore }}
+              <s>{{ site.Params.currencySymbol }}{{ .Params.PriceBefore }}</s>
+              {{ end }}
+              <span class="lead text-primary">{{ site.Params.currencySymbol }}{{ .Params.Price }}</span>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
               data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -17,8 +17,10 @@
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
             <p>{{ .Params.Description }}</p>
             <div class="mb-4">
-              <span class="lead text-primary">{{ .Params.Price }} {{ site.Params.currencySymbol }}</span>
-              <s>{{ .Params.PriceBefore }} {{ site.Params.currencySymbol }}</s>
+              {{ if .Params.PriceBefore }}
+              <s>{{ site.Params.currencySymbol }}{{ .Params.PriceBefore }}</s>
+              {{ end }}
+              <span class="lead text-primary">{{ site.Params.currencySymbol }}{{ .Params.Price }}</span>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
               data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -22,8 +22,10 @@
         <div class="rw-ui-container"></div>
         {{ end }}
         <div class="my-4">
-          <span class="lead text-primary font-weight-medium">{{ .Params.Price }} {{ site.Params.currencySymbol }}</span>
-          <s>{{ .Params.PriceBefore }} {{ site.Params.currencySymbol }}</s>
+          {{ if .Params.PriceBefore }}
+          <s>{{ site.Params.currencySymbol }}{{ .Params.PriceBefore }}</s>
+          {{ end }}
+          <span class="lead text-primary font-weight-medium">{{ site.Params.currencySymbol }}{{ .Params.Price }}</span>
         </div>
         <h5>Short Description</h5>
         <p>{{ .Params.ShortDescription | markdownify }}</p>


### PR DESCRIPTION
This addresses issue #27. I also reordered the currency symbol to be before the price like most stores using USD, so feel free to move it back if you prefer the original order.